### PR TITLE
Give health on Kill Enemy

### DIFF
--- a/DeathmatchPlugin/DeathmatchPlugin.cs
+++ b/DeathmatchPlugin/DeathmatchPlugin.cs
@@ -135,6 +135,7 @@ public class DeathmatchPlugin : BasePlugin
         _killstreakManager.OnKill(attacker);
 
         RefillPlayerAmmo.Do(attacker);
+        RefillPlayerHealth.onKill(attacker);
 
         return HookResult.Continue;
     }

--- a/DeathmatchPlugin/Effects/RefillPlayerHealth.cs
+++ b/DeathmatchPlugin/Effects/RefillPlayerHealth.cs
@@ -1,0 +1,33 @@
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Memory;
+using DeathmatchPlugin.Config;
+using DeathmatchPlugin.Utilities;
+namespace DeathmatchPlugin.Effects;
+
+public static class RefillPlayerHealth {
+
+    public static void onKill(CCSPlayerController player)
+    {
+        if (player.Health == 100) return;
+        string giveBack = "weapon_healthshot";
+        string playerName = player.PlayerName;
+        player.PlayerPawn.Value.Health = 100; // give health
+        player.PlayerPawn.Value.MaxHealth = 100;
+        player.PlayerPawn.Value.ArmorValue = 100; // give armor
+        //  PrintChat giveHealth
+        player.PrintToChat($"{DeathmatchConfig.ChatPrefix} {Colored.Blue(playerName)} : {Colored.Green("+100")} hp");
+        /*
+            Due to the nature of the HUD, the HUD is not updated until an action is taken by an external factor, 
+            so the HUD is updated using healthShot.
+        */
+        foreach (var weapon in player.PlayerPawn.Value.WeaponServices!.MyWeapons)
+        {
+            if (weapon is { IsValid:true, Value.IsValid: true } && weapon.Value.DesignerName.Contains("healthshot")) {
+                giveBack = weapon.Value.DesignerName;
+                weapon.Value.Remove();
+            }
+        }
+        // give HealthShot
+        VirtualFunctions.GiveNamedItem(player.PlayerPawn.Value.ItemServices!.Handle, giveBack, 0, 0, 0, 0);
+    }
+}


### PR DESCRIPTION
hi! nadir!
Thanks for creating a very good plugin!

I have created an Effects that provides a function to recover when an enemy is defeated, based on the plugin you have created
I know my source is lousy, but if you think it's a good idea, please Merge it

Ensure that health is restored when an enemy is killed. Also, toggle the "give health shot" option when updating the HUD to keep the HUD updated. This would allow the HUD to be updated in a way that does not detract from the player's experience.

HUD Updated tech by K4ryuu
https://discord.com/channels/1160907911501991946/1160907912445710482/1173076426753331283

Use a translator this Comment